### PR TITLE
修正了xml代码格式以保证在webstorm10下面也能够自动提示不再需要输入`<`引导，在Mac也不会受到ctrl+space快捷键冲突的麻烦

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -121,8 +121,9 @@ function compileWebstorm() {
       '  <template name="' + triggerName + '" value="' + snippet + '" toReformat="true" toShortenFQNames="true">\n',
       tabVariable.join(''),
       '    <context>',
-      '      <option name="HTML_TEXT" value="true" />',
-      '      <option name="HTML" value="true" />',
+      '      <option name="XSL_TEXT" value="true" />',
+      '      <option name="XML_TEXT" value="true" />',
+      '      <option name="XML" value="true" />',
       '    </context>',
       '  </template>'
     ].join('\n');


### PR DESCRIPTION
通过修改属性发现webstorm10 对html自动提示做了限制必须有`<`才行。
通过测试发现当将提示属性更改为xml后正常自动提示